### PR TITLE
Change config/config.py path to config.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ USER discoverylastfm
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV CONFIG_PATH="/app/config/config.py"
+ENV CONFIG_PATH="/app/config.py"
 ENV LOG_PATH="/app/logs"
 ENV CACHE_PATH="/app/cache"
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ docker compose up -d
 ### Configuration Test
 ```bash
 # Test configuration
-docker compose exec discoverylastfm python /app/config/config.py
+docker compose exec discoverylastfm python /app/config.py
 ```
 
 ## 🚨 Troubleshooting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - REQUEST_LIMIT=0.2
       - MBZ_DELAY=1.1
       # === CONTAINER PATHS ===
-      - CONFIG_PATH=/app/config/config.py
+      - CONFIG_PATH=/app/config.py
       - LOG_PATH=/app/logs
       - CACHE_PATH=/app/cache
       # === AUTO-UPDATE SYSTEM (v2.1.0+) REQUIRED ===
@@ -78,7 +78,7 @@ services:
       - logs:/app/logs
       - cache:/app/cache
       # Optional: Mount external config
-      # - ./config/config.py:/app/config/config.py:ro
+      # - ./config.py:/app/config.py:ro
       # Optional: Mount music directory (for Lidarr compatibility)
       # - /path/to/music:/music:ro
     # Health check

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,7 +33,7 @@ log_debug() {
 }
 
 # Default paths
-CONFIG_PATH="${CONFIG_PATH:-/app/config/config.py}"
+CONFIG_PATH="${CONFIG_PATH:-/app/config.py}"
 CONFIG_EXAMPLE_PATH="/app/config.example.py"
 LOG_PATH="${LOG_PATH:-/app/logs}"
 CACHE_PATH="${CACHE_PATH:-/app/cache}"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -135,7 +135,7 @@ DEBUG=false
 Test your configuration:
 ```bash
 # Validate configuration
-docker-compose exec discoverylastfm python /app/config/config.py
+docker-compose exec discoverylastfm python /app/config.py
 
 # Test service connectivity
 docker-compose exec discoverylastfm /usr/local/bin/health-check config
@@ -602,10 +602,10 @@ python -c "from services.factory import MusicServiceFactory; print('OK')"
 #### Reset Configuration
 ```bash
 # Backup current config
-docker-compose exec discoverylastfm cp /app/config/config.py /app/config/config.py.backup
+docker-compose exec discoverylastfm cp /app/config.py /app/config.py.backup
 
 # Reset to defaults
-docker-compose exec discoverylastfm cp /app/config.example.py /app/config/config.py
+docker-compose exec discoverylastfm cp /app/config.example.py /app/config.py
 
 # Restart with clean config
 docker-compose restart discoverylastfm

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Default paths
-CONFIG_PATH="${CONFIG_PATH:-/app/config/config.py}"
+CONFIG_PATH="${CONFIG_PATH:-/app/config.py}"
 LOG_PATH="${LOG_PATH:-/app/logs}"
 # APP_PID_FILE="/tmp/discoverylastfm.pid"  # Currently unused
 


### PR DESCRIPTION
The main DiscoveryLastFM.py script expects a `config.py` script instead of `config/config.py`.

This fixes #4 , which is caused to due DiscoveryLastFM.py not correctly detecting `config.py`, and instead using the default values.